### PR TITLE
Add min_auth_mode: WPA2 to wifi configuration

### DIFF
--- a/esp32-epever-4210an.yaml
+++ b/esp32-epever-4210an.yaml
@@ -25,6 +25,7 @@ ota:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
   ap:
     ssid: !secret ap_wifi_ssid
     password: !secret ap_wifi_password

--- a/esp32-phnix-heroplus-heat-pump.yaml
+++ b/esp32-phnix-heroplus-heat-pump.yaml
@@ -25,6 +25,7 @@ ota:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
   ap:
     ssid: !secret ap_wifi_ssid
     password: !secret ap_wifi_password

--- a/esp32-shinewifi-f-dongle.yaml
+++ b/esp32-shinewifi-f-dongle.yaml
@@ -33,6 +33,7 @@ ota:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 uart:
   - id: uart_0

--- a/esp8266-d0-pulse-meter.yaml
+++ b/esp8266-d0-pulse-meter.yaml
@@ -20,6 +20,7 @@ ota:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
   ap:
     ssid: !secret ap_wifi_ssid
     password: !secret ap_wifi_password

--- a/esp8266-gas-meter.yaml
+++ b/esp8266-gas-meter.yaml
@@ -32,6 +32,7 @@ ota:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
   ap:
     ssid: !secret ap_wifi_ssid
     password: !secret ap_wifi_password

--- a/esp8266-led-ring-gauge.yaml
+++ b/esp8266-led-ring-gauge.yaml
@@ -20,6 +20,7 @@ ota:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
   ap:
     ssid: !secret ap_wifi_ssid
     password: !secret ap_wifi_password

--- a/esp8266-voltronic-rp-rs.yaml
+++ b/esp8266-voltronic-rp-rs.yaml
@@ -27,6 +27,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp8266-epever-dummy.yaml
+++ b/tests/esp8266-epever-dummy.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 api:
 

--- a/tests/esp8266-epever-test.yaml
+++ b/tests/esp8266-epever-test.yaml
@@ -21,6 +21,7 @@ ota:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 time:
   - platform: sntp

--- a/tests/esp8266-junctek-kh-f-dummy.yaml
+++ b/tests/esp8266-junctek-kh-f-dummy.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 api:
 ota:

--- a/tests/esp8266-voltronic-rp-rs-dummy.yaml
+++ b/tests/esp8266-voltronic-rp-rs-dummy.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome


### PR DESCRIPTION
Add `min_auth_mode: WPA2` to all `wifi:` blocks in ESPHome YAML configurations.

This sets the minimum WiFi authentication mode to WPA2 (AES encryption), which:

- Silences the ESPHome deprecation warning that will change defaults in 2026.6.0
- Ensures WPA2 is used instead of WPA (TKIP), which is more secure

Without this setting, ESPHome 2026.6.0 will emit a deprecation warning and future versions may change the default behavior.